### PR TITLE
Bump to `go` `1.16.7`

### DIFF
--- a/cmd/_internal_/objabi/zbootstrap.go
+++ b/cmd/_internal_/objabi/zbootstrap.go
@@ -13,6 +13,6 @@ const defaultGOOS = runtime.GOOS
 const defaultGOARCH = runtime.GOARCH
 const defaultGO_EXTLINK_ENABLED = ``
 const defaultGO_LDSO = ``
-const version = `go1.16.3`
+const version = `go1.16.7`
 const stackGuardMultiplierDefault = 1
 const goexperiment = ``

--- a/cmd/go/_internal_/cfg/zdefaultcc.go
+++ b/cmd/go/_internal_/cfg/zdefaultcc.go
@@ -7,10 +7,10 @@ const DefaultPkgConfig = `pkg-config`
 func DefaultCC(goos, goarch string) string {
 	switch goos + `/` + goarch {
 	}
-	return "clang"
+	return "gcc"
 }
 func DefaultCXX(goos, goarch string) string {
 	switch goos + `/` + goarch {
 	}
-	return "clang++"
+	return "g++"
 }

--- a/cmd/go/_internal_/modload/buildlist.go
+++ b/cmd/go/_internal_/modload/buildlist.go
@@ -11,10 +11,13 @@ import (
 	"github.com/dependabot/gomodules-extracted/cmd/go/_internal_/mvs"
 	"context"
 	"fmt"
+	"go/build"
 	"os"
 	"strings"
 
+	"golang.org/x/mod/modfile"
 	"golang.org/x/mod/module"
+	"golang.org/x/mod/semver"
 )
 
 // buildList is the list of modules to use for building packages.
@@ -224,6 +227,33 @@ func ReloadBuildList() []module.Version {
 		allClosesOverTests:	index.allPatternClosesOverTests(),	// but doesn't matter because the root list is empty.
 	})
 	return capVersionSlice(buildList)
+}
+
+// CheckTidyVersion reports an error to stderr if the Go version indicated by
+// the go.mod file is not supported by this version of the 'go' command.
+//
+// If allowError is false, such an error terminates the program.
+func CheckTidyVersion(ctx context.Context, allowError bool) {
+	LoadModFile(ctx)
+	if index.goVersionV == "" {
+		return
+	}
+
+	tags := build.Default.ReleaseTags
+	maxGo := tags[len(tags)-1]
+	if !strings.HasPrefix(maxGo, "go") || !modfile.GoVersionRE.MatchString(maxGo[2:]) {
+		base.Fatalf("go: unrecognized go version %q", maxGo)
+	}
+	max := maxGo[2:]
+
+	if semver.Compare(index.goVersionV, "v"+max) > 0 {
+		have := index.goVersionV[1:]
+		if allowError {
+			fmt.Fprintf(os.Stderr, "go mod tidy: go.mod file indicates go %s, but maximum supported version is %s\n", have, max)
+		} else {
+			base.Fatalf("go mod tidy: go.mod file indicates go %s, but maximum supported version is %s\n", have, max)
+		}
+	}
 }
 
 // TidyBuildList trims the build list to the minimal requirements needed to

--- a/cmd/go/_internal_/modload/import.go
+++ b/cmd/go/_internal_/modload/import.go
@@ -160,11 +160,13 @@ func (e *ImportMissingSumError) Error() string {
 		// Importing package is unknown, or the missing package was named on the
 		// command line. Recommend 'go mod download' for the modules that could
 		// provide the package, since that shouldn't change go.mod.
-		args := make([]string, len(e.mods))
-		for i, mod := range e.mods {
-			args[i] = mod.Path
+		if len(e.mods) > 0 {
+			args := make([]string, len(e.mods))
+			for i, mod := range e.mods {
+				args[i] = mod.Path
+			}
+			hint = fmt.Sprintf("; to add:\n\tgo mod download %s", strings.Join(args, " "))
 		}
-		hint = fmt.Sprintf("; to add:\n\tgo mod download %s", strings.Join(args, " "))
 	} else {
 		// Importing package is known (common case). Recommend 'go get' on the
 		// current version of the importing package.

--- a/cmd/go/_internal_/robustio/robustio_other.go
+++ b/cmd/go/_internal_/robustio/robustio_other.go
@@ -7,7 +7,6 @@
 package robustio
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -16,7 +15,7 @@ func rename(oldpath, newpath string) error {
 }
 
 func readFile(filename string) ([]byte, error) {
-	return ioutil.ReadFile(filename)
+	return os.ReadFile(filename)
 }
 
 func removeAll(path string) error {


### PR DESCRIPTION
This bumps to `go` `1.16.7` generated via:
```
$ docker run -v ~/Code/open-source/dependabot/gomodules-extracted:/gomodules -it --rm  golang:1.16.7
root@f5a9ea6a8efe:/go# cd /gomodules/
root@f5a9ea6a8efe:/gomodules# ./script/extract
```