### PR TITLE
Remove outdated warning

### DIFF
--- a/extract/main.go
+++ b/extract/main.go
@@ -25,6 +25,4 @@ func main() {
 	if err := extractor.Run(); err != nil {
 		log.Fatal(err)
 	}
-
-	fmt.Println("!!! Remember to copy the LICENSE across - https://raw.githubusercontent.com/golang/go/master/LICENSE")
 }


### PR DESCRIPTION
IIUC, the `script/extract` code is already doing this: https://github.com/dependabot/gomodules-extracted/blob/906572ac056cee6a477081d303aa73c9d38fe2c0/script/extract#L5